### PR TITLE
Shorten the solution of combineLists in ch11

### DIFF
--- a/11-functors-applicative-functors-and-monoids.hs
+++ b/11-functors-applicative-functors-and-monoids.hs
@@ -12,7 +12,6 @@ instance Functor List where
 -- Write a function which appends one list on to another
 combineLists:: List a -> List a -> List a
 combineLists Empty other = other
-combineLists other Empty = other
 combineLists (Value v rest) other = Value v (combineLists rest other)
 
 -- Make our list a Monoid


### PR DESCRIPTION
`combineLists other Empty = other` isn't needed: in case the second list is empty, it'll be pattern matched against `combineLists (Value v rest) other` and go on in this way until the first List is Empty.